### PR TITLE
(Android): EVENT_UPDATE: Plugin will handle EVENT_UPDATE notification type for calendar reminder

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -105,8 +105,19 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
         PushPlugin.setApplicationIconBadgeNumber(getApplicationContext(), 0);
       }
 
+      // if Push notification is EVENT update then scheduled received event change.
+      if(extras.get("notificationType") != null) {
+        if(extras.get("notificationType").equals("EVENT_UPDATE")) {
+          Log.d("EVENT_UPDATE", "EVENT_UPDATE Received");
+          try {
+            PushPlugin.sendExtras_Event_Update(extras, applicationContext);
+          } catch (JSONException e) {
+            e.printStackTrace();
+          }
+        }
+      }
       // if we are in the foreground and forceShow is `false` only send data
-      if (!forceShow && PushPlugin.isInForeground()) {
+      else if (!forceShow && PushPlugin.isInForeground()) {
         Log.d(LOG_TAG, "foreground");
         extras.putBoolean(FOREGROUND, true);
         extras.putBoolean(COLDSTART, false);

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -29,6 +29,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.Date;
@@ -513,42 +515,93 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
     }
   }
 
-   public static  void sendExtras_Event_Update (Bundle extras, Context context) throws JSONException {
+    public static  void sendExtras_Event_Update (Bundle extras, Context context) throws JSONException {
     if (extras != null) {
-        Log.d("EVENT_UPDATE", "Event update received in background");
+      Log.d("EVENT_UPDATE", "Event update received in background");
 
-        if(extras.get("messageId") != null) {
-          // Cancelled current notification from local scheduled if already present.
-          LocalNotification.cancel_Event_Update(Integer.parseInt(extras.get("messageId").toString()), context);
+      if(extras.get("messageId") != null) {
+        cancelPreviousScheduledEvent(extras.getString("messageId"), context);
 
-          //Scheduled current event
-          JSONArray EventData = convertJSONArray(convertBundleToJson_Event_Update(extras));
-          LocalNotification.schedule_Event_Update(EventData, context);
+        JSONArray EventData = convertJSONArray(convertBundleToJson_Event_Update(extras));
+        LocalNotification.schedule_Event_Update(EventData, context);
 
-          // Clear notification after timeout
-          if(extras.get("clearAt") != null) {
-            new java.util.Timer().schedule(
-                    new java.util.TimerTask() {
-                      @Override
-                      public void run() {
-                        LocalNotification.clear_Event_Update(Integer.parseInt(extras.get("messageId").toString()), context);
-                      }
-                    },
-                    clearNotificationTimeOut(extras)
-            );
-          }
-        } else {
-          Log.d("EVENT_UPDATE", "messageId is missing in the event payload");
-        }
+      } else {
+        Log.d("EVENT_UPDATE", "messageId is missing in the event payload");
+      }
     }
   }
 
-  private static JSONArray convertJSONArray(JSONObject obj) {
+private static JSONArray convertJSONArray(JSONObject fcmData) {
 
-Log.d("EVENT_UPDATE", "Converting JsonObject to JsonArray");
-    JSONObject trigger = new JSONObject();
-    JSONObject progressBar = new JSONObject();
+    Log.d("EVENT_UPDATE", "Converting JsonObject to JsonArray");
+    JSONArray jsonArray = new JSONArray();
+
+      try {
+
+        Long nextAlarm = Long.parseLong(fcmData.get("nextAlarm").toString());
+        JSONArray instances = fcmData.getJSONArray("instances");
+
+        for(int i=0; i< instances.length(); i++) {
+            JSONObject instance = instances.getJSONObject(i);
+            if(Long.parseLong(instance.getString("start")) >= nextAlarm) {
+
+              // Create new default notification object per instance
+              JSONObject notificationObj = getDefaultNotification(fcmData);
+
+              // Update trigger key with instance start time.
+              JSONObject updatedTrigger = new JSONObject();
+              updatedTrigger.put("type", "calendar");
+              updatedTrigger.put("at", Long.parseLong(instance.getString("start")));
+
+              notificationObj.remove("trigger");
+              notificationObj.put("trigger", updatedTrigger);
+
+
+              // Assing event id to number key so when update happend to this event then first plugin remove all schedule old instance based on this number value
+              notificationObj.remove("number");
+              notificationObj.put("number", Long.parseLong(fcmData.getString("messageId")));
+
+              // Set notification unique id.
+              notificationObj.remove("id");
+              notificationObj.put("id", Long.parseLong(fcmData.getString("messageId") + (i+1));
+
+              jsonArray.put(notificationObj);
+            }
+        }
+
+      } catch (JSONException e) {
+        e.printStackTrace();
+      }
+
+    return jsonArray;
+  }
+
+ private static void cancelPreviousScheduledEvent(String messageId, Context context) {
+
+    // Get all previously schedule notification and cancel notiication which is associate with this event
+
+    JSONArray scheduledNotification = LocalNotification.notifications_EVENT_UPDATE(context);
+
+    try {
+      for (int i = 0; i < scheduledNotification.length(); i++) {
+        JSONObject jobject = scheduledNotification.getJSONObject(i);
+
+        if(jobject.getString("number").equals(messageId)) {
+          LocalNotification.cancel_Event_Update(jobject.getInt("id"), context);
+        }
+      }
+    } catch (JSONException e) {
+      e.printStackTrace();
+    }
+
+  }
+
+ private static JSONObject getDefaultNotification(JSONObject fcmObject) {
     JSONObject jsonObject = new JSONObject();
+    JSONObject trigger = new JSONObject();
+
+    // Default Json object with keys value that local notification plugin require.
+    JSONObject progressBar = new JSONObject();
     try {
       trigger.put("type", "calendar");
 
@@ -586,53 +639,44 @@ Log.d("EVENT_UPDATE", "Converting JsonObject to JsonArray");
       jsonObject.put("sticky", false);
       jsonObject.put("summary", null);
       jsonObject.put("text", "");
-      jsonObject.put("timeoutAfter", false);
+      jsonObject.put("timeoutAfter", 5*60*1000);
       jsonObject.put("title", "");
       jsonObject.put("trigger", trigger);
       jsonObject.put("vibrate", false);
       jsonObject.put("wakeup", true);
 
+
+
+    // Update default notification jsonObject's key value as per FCM Payload data.
+      Iterator x = fcmObject.keys();
+
+      while (x.hasNext()) {
+        String key = (String) x.next();
+        try {
+          if (jsonObject.has(key)) {
+            jsonObject.remove(key);
+            jsonObject.put(key, fcmObject.get(key));
+          }
+        } catch (JSONException e) {
+          e.printStackTrace();
+        }
+      }
+
+      // if FCM payload contains event start time then update notification text key
+      if(fcmObject.has("alarmInstStart")) {
+
+        DateFormat dateFormat = new SimpleDateFormat("hh:mm a");
+        Timestamp ts = new Timestamp(Long.parseLong(fcmObject.getString("alarmInstStart")));
+        Date date=new Date(ts.getTime());
+        jsonObject.remove("text");
+        jsonObject.put("text", "Today at " + dateFormat.format(date));
+      }
+
     } catch (JSONException e) {
       e.printStackTrace();
     }
+  return jsonObject;
 
-
-    Iterator x = obj.keys();
-
-    while (x.hasNext()){
-      String key = (String) x.next();
-      try {
-        if(jsonObject.has(key)) {
-          jsonObject.remove(key);
-          jsonObject.put(key, obj.get(key));
-        }
-      } catch (JSONException e) {
-        e.printStackTrace();
-      }
-    }
-
-    if(obj.has("messageId")) {
-      try {
-        jsonObject.remove("id");
-        jsonObject.put("id", Integer.parseInt(obj.get("messageId").toString()));
-      } catch (JSONException e) {
-        e.printStackTrace();
-      }
-    }
-
-    if(obj.has("alarm")) {
-      try {
-        Timestamp currentTimeStamp = new Timestamp((new Date()).getTime());
-        Timestamp eventTimeStamp = new Timestamp(Long.parseLong(obj.get("alarm").toString()));
-        int second = (int)(eventTimeStamp.getTime() - currentTimeStamp.getTime())/1000;
-        trigger.put("in", second);
-        trigger.put("unit", "second");
-      } catch (JSONException e) {
-        e.printStackTrace();
-      }
-    }
-
-    return new JSONArray().put(jsonObject);
   }
 
   private static JSONObject convertBundleToJson_Event_Update (Bundle extras) {

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -29,12 +29,15 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.appplant.cordova.plugin.localnotification.LocalNotification;
 import me.leolin.shortcutbadger.ShortcutBadger;
 
 public class PushPlugin extends CordovaPlugin implements PushConstants {
@@ -508,6 +511,199 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
         gCachedExtras.add(extras);
       }
     }
+  }
+
+   public static  void sendExtras_Event_Update (Bundle extras, Context context) throws JSONException {
+    if (extras != null) {
+        Log.d("EVENT_UPDATE", "Event update received in background");
+
+        if(extras.get("messageId") != null) {
+          // Cancelled current notification from local scheduled if already present.
+          LocalNotification.cancel_Event_Update(Integer.parseInt(extras.get("messageId").toString()), context);
+
+          //Scheduled current event
+          JSONArray EventData = convertJSONArray(convertBundleToJson_Event_Update(extras));
+          LocalNotification.schedule_Event_Update(EventData, context);
+
+          // Clear notification after timeout
+          if(extras.get("clearAt") != null) {
+            new java.util.Timer().schedule(
+                    new java.util.TimerTask() {
+                      @Override
+                      public void run() {
+                        LocalNotification.clear_Event_Update(Integer.parseInt(extras.get("messageId").toString()), context);
+                      }
+                    },
+                    clearNotificationTimeOut(extras)
+            );
+          }
+        } else {
+          Log.d("EVENT_UPDATE", "messageId is missing in the event payload");
+        }
+    }
+  }
+
+  private static JSONArray convertJSONArray(JSONObject obj) {
+
+Log.d("EVENT_UPDATE", "Converting JsonObject to JsonArray");
+    JSONObject trigger = new JSONObject();
+    JSONObject progressBar = new JSONObject();
+    JSONObject jsonObject = new JSONObject();
+    try {
+      trigger.put("type", "calendar");
+
+      progressBar.put("enabled", false);
+      progressBar.put("value", 0);
+      progressBar.put("maxValue", 100);
+      progressBar.put("indeterminate", false);
+
+
+      jsonObject.put("action",new JSONArray());
+      jsonObject.put("attachment", new JSONArray());
+      jsonObject.put("autoClear", true);
+      jsonObject.put("badge", null);
+      jsonObject.put("channel", null);
+      jsonObject.put("clock", true);
+      jsonObject.put("data", null);
+      jsonObject.put("color", null);
+      jsonObject.put("defaults", 0);
+      jsonObject.put("foreground", null);
+      jsonObject.put("group", null);
+      jsonObject.put("groupSummary", false);
+      jsonObject.put("icon", null);
+      jsonObject.put("iconTYpe", null);
+      jsonObject.put("id", 0);
+      jsonObject.put("launch", true);
+      jsonObject.put("led", true);
+      jsonObject.put("lockscreen", true);
+      jsonObject.put("mediaSession", null);
+      jsonObject.put("number", 0);
+      jsonObject.put("priority", 0);
+      jsonObject.put("progressBar", progressBar);
+      jsonObject.put("silent", false);
+      jsonObject.put("smallIcon", "res://icon");
+      jsonObject.put("sound", true);
+      jsonObject.put("sticky", false);
+      jsonObject.put("summary", null);
+      jsonObject.put("text", "");
+      jsonObject.put("timeoutAfter", false);
+      jsonObject.put("title", "");
+      jsonObject.put("trigger", trigger);
+      jsonObject.put("vibrate", false);
+      jsonObject.put("wakeup", true);
+
+    } catch (JSONException e) {
+      e.printStackTrace();
+    }
+
+
+    Iterator x = obj.keys();
+
+    while (x.hasNext()){
+      String key = (String) x.next();
+      try {
+        if(jsonObject.has(key)) {
+          jsonObject.remove(key);
+          jsonObject.put(key, obj.get(key));
+        }
+      } catch (JSONException e) {
+        e.printStackTrace();
+      }
+    }
+
+    if(obj.has("messageId")) {
+      try {
+        jsonObject.remove("id");
+        jsonObject.put("id", Integer.parseInt(obj.get("messageId").toString()));
+      } catch (JSONException e) {
+        e.printStackTrace();
+      }
+    }
+
+    if(obj.has("alarm")) {
+      try {
+        Timestamp currentTimeStamp = new Timestamp((new Date()).getTime());
+        Timestamp eventTimeStamp = new Timestamp(Long.parseLong(obj.get("alarm").toString()));
+        int second = (int)(eventTimeStamp.getTime() - currentTimeStamp.getTime())/1000;
+        trigger.put("in", second);
+        trigger.put("unit", "second");
+      } catch (JSONException e) {
+        e.printStackTrace();
+      }
+    }
+
+    return new JSONArray().put(jsonObject);
+  }
+
+  private static JSONObject convertBundleToJson_Event_Update (Bundle extras) {
+    Log.d("EVENT_UPDATE", "convert extras to json");
+    try {
+      JSONObject json = new JSONObject();
+      JSONObject additionalData = new JSONObject();
+
+      // Add any keys that need to be in top level json to this set
+      HashSet<String> jsonKeySet = new HashSet();
+      Collections.addAll(jsonKeySet, TITLE, MESSAGE, COUNT, SOUND, IMAGE);
+
+      Iterator<String> it = extras.keySet().iterator();
+      while (it.hasNext()) {
+        String key = it.next();
+        Object value = extras.get(key);
+
+        Log.d(LOG_TAG, "key = " + key);
+
+        if (jsonKeySet.contains(key)) {
+          json.put(key, value);
+        } else if (key.equals(COLDSTART)) {
+          additionalData.put(key, extras.getBoolean(COLDSTART));
+        } else if (key.equals(FOREGROUND)) {
+          additionalData.put(key, extras.getBoolean(FOREGROUND));
+        } else if (key.equals(DISMISSED)) {
+          additionalData.put(key, extras.getBoolean(DISMISSED));
+        } else if (value instanceof String) {
+          String strValue = (String) value;
+          try {
+            // Try to figure out if the value is another JSON object
+            if (strValue.startsWith("{")) {
+              json.put(key, new JSONObject(strValue));
+            }
+            // Try to figure out if the value is another JSON array
+            else if (strValue.startsWith("[")) {
+              json.put(key, new JSONArray(strValue));
+            } else {
+              json.put(key, value);
+            }
+          } catch (Exception e) {
+            json.put(key, value);
+          }
+        }
+      } // while
+
+      json.put(ADDITIONAL_DATA, additionalData);
+      Log.v(LOG_TAG, "extrasToJSON: " + json.toString());
+
+      return json;
+    } catch (JSONException e) {
+      Log.e(LOG_TAG, "extrasToJSON: JSON exception");
+    }
+    return null;
+  }
+
+
+  private static int clearNotificationTimeOut(Bundle extras) {
+
+    try {
+      if (extras.get("clearAt") != null) {
+        Timestamp currentTimeStamp = new Timestamp((new Date()).getTime());
+        Timestamp eventTimeStamp = new Timestamp(Long.parseLong(extras.get("clearAt").toString()));
+        int miliSecond = (int) (eventTimeStamp.getTime() - currentTimeStamp.getTime());
+        return miliSecond;
+      }
+      return 0;
+    } catch (NullPointerException e) {
+      return 0;
+    }
+
   }
 
   /*


### PR DESCRIPTION
Updated plugin to handle EVENT_TYPE notification. Plugin will received EVENT_TYPE push notification and schedule local notification to show calendar reminder local notification when alarm arrive and get clear automatically when after default 5 mins.

**FCM Sample PAYLOAD:**

{
  "to":"Android_device_token",
  "data": {
    "title":"Event 9:27PM", 
    "notificationType": "EVENT_UPDATE",
    "launch": false,
    "messageId": 1013,
    "nextAlarm": "1625223680606",
    "alarmInstStart": "1625239880606",
    "instances": [
        { "start": 1625223680606, "utcRecurrenceId": "20210705T163000Z"},
        { "start": 1625226680606 , "utcRecurrenceId": "20210706T163000Z"},
        { "start": 1625232680606 , "utcRecurrenceId": "20210708T163000Z"}
    ]
}

- alarm:  "TimeStamp"  `At what time calendar reminder local notification to be display.`
- clearAt "TimeStamp"  `At what time calendar reminder local notification to be clear.`
- launch: false  `On clicking notification, App will not open and it clears notification.`
- messageId: "id of event"  `It should be unique and mandatory.`
- notificationType: "EVENT_UPDATE"  `It should be mandatory to show calendar reminder.`
- title: "Event Subject"
- text: "Event Time details"