### PR TITLE
PREAPPS-6259: Android | handled fcm configuration at runtime

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@
     </config-file>
 
     <config-file target="config.xml" parent="/*">
-      <preference name="GradlePluginGoogleServicesEnabled" value="true" />
+      <preference name="GradlePluginGoogleServicesEnabled" value="false" />
       <preference name="GradlePluginGoogleServicesVersion" value="4.2.0" />
     </config-file>
 
@@ -77,6 +77,7 @@
     <source-file src="src/android/com/adobe/phonegap/push/PushPlugin.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushDismissedHandler.java" target-dir="src/com/adobe/phonegap/push/"/>
+    <source-file src="src/android/com/adobe/phonegap/push/ZimbraFirebaseApp.java" target-dir="src/com/adobe/phonegap/push/"/>
   </platform>
 
   <platform name="browser">

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -29,6 +29,7 @@ import android.support.v4.app.RemoteInput;
 import android.text.Html;
 import android.text.Spanned;
 import android.util.Log;
+import java.util.Date;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
@@ -103,6 +104,11 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
 
       if (clearBadge) {
         PushPlugin.setApplicationIconBadgeNumber(getApplicationContext(), 0);
+      }
+
+      if(extras.getInt(NOT_ID) == 0) {
+        int notId = (int) (new Date().getTime() / 1000);
+        extras.putInt(NOT_ID, notId);
       }
 
       // if we are in the foreground and forceShow is `false` only send data
@@ -282,6 +288,17 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
               String newKey = normalizeKey(key, messageKey, titleKey, newExtras);
               Log.d(LOG_TAG, "replace key " + key + " with " + newKey);
               replaceKey(context, key, newKey, extras, newExtras);
+            } else {
+              Iterator<String> jsonIter = data.keys();
+              while (jsonIter.hasNext()) {
+                String jsonKey = jsonIter.next();
+
+                Log.d(LOG_TAG, "key = data/" + jsonKey);
+
+                String value = data.getString(jsonKey);
+
+                newExtras.putString(jsonKey, value);
+              }
             }
           } catch (JSONException e) {
             Log.e(LOG_TAG, "normalizeExtras: JSON exception");
@@ -392,7 +409,8 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
     String packageName = context.getPackageName();
     Resources resources = context.getResources();
 
-    int notId = parseInt(NOT_ID, extras);
+    int notId = extras.getInt(NOT_ID);
+    
     Intent notificationIntent = new Intent(this, PushHandlerActivity.class);
     notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
     notificationIntent.putExtra(PUSH_BUNDLE, extras);
@@ -1053,10 +1071,10 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
 
   private boolean isAvailableSender (String from) {
     SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(
-      PushPlugin.COM_ADOBE_PHONEGAP_PUSH,
-      Context.MODE_PRIVATE
+            "zimbraMobile",
+            Context.MODE_PRIVATE
     );
-    String savedSenderID = sharedPref.getString(SENDER_ID, "");
+    String savedSenderID = sharedPref.getString("senderID", "");
 
     Log.d(LOG_TAG, "sender id = " + savedSenderID);
 

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -16,7 +16,6 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.util.Log;
 
-import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.messaging.FirebaseMessaging;
 
 import org.apache.cordova.CallbackContext;
@@ -216,19 +215,18 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
 
             Log.v(LOG_TAG, "execute: jo=" + jo.toString());
 
-            senderID = getStringResourceByName(GCM_DEFAULT_SENDER_ID);
-
-            Log.v(LOG_TAG, "execute: senderID=" + senderID);
 
             try {
-              token = FirebaseInstanceId.getInstance().getToken();
+              ZimbraFirebaseApp.init(getApplicationContext(), data.getJSONObject(0).getJSONObject("fcm"));
+
+              token = ZimbraFirebaseApp.getInstance().getToken();
             } catch (IllegalStateException e) {
               Log.e(LOG_TAG, "Exception raised while getting Firebase token " + e.getMessage());
             }
 
             if (token == null) {
               try {
-                token = FirebaseInstanceId.getInstance().getToken(senderID, FCM);
+                 token = ZimbraFirebaseApp.getInstance().getToken(ZimbraFirebaseApp.getSenderId(), FCM);
               } catch (IllegalStateException e) {
                 Log.e(LOG_TAG, "Exception raised while getting Firebase token " + e.getMessage());
               }
@@ -314,7 +312,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
             if (topics != null && !"".equals(registration_id)) {
               unsubscribeFromTopics(topics, registration_id);
             } else {
-              FirebaseInstanceId.getInstance().deleteInstanceId();
+              ZimbraFirebaseApp.getInstance().deleteInstanceId();
               Log.v(LOG_TAG, "UNREGISTER");
 
               // Remove shared prefs
@@ -642,6 +640,8 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
           additionalData.put(key, extras.getBoolean(FOREGROUND));
         } else if (key.equals(DISMISSED)) {
           additionalData.put(key, extras.getBoolean(DISMISSED));
+        } else if (key.equals(NOT_ID)) {
+          additionalData.put(key, extras.getInt(NOT_ID));
         } else if (value instanceof String) {
           String strValue = (String) value;
           try {

--- a/src/android/com/adobe/phonegap/push/ZimbraFirebaseApp.java
+++ b/src/android/com/adobe/phonegap/push/ZimbraFirebaseApp.java
@@ -1,0 +1,57 @@
+package com.adobe.phonegap.push;
+
+import android.content.Context;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.iid.FirebaseInstanceId;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class ZimbraFirebaseApp {
+
+    private static ZimbraFirebaseApp objInstance = null;
+    private static FirebaseOptions firebaseOptions = null;
+    private static FirebaseApp objFirebase = null;
+    private static String senderId = "";
+    private ZimbraFirebaseApp(){
+
+    }
+
+    public static void init(Context context, JSONObject FCMConfig) throws JSONException {
+        if (objInstance == null) {
+            firebaseOptions = new FirebaseOptions.Builder()
+                    .setApplicationId(FCMConfig.getString("applicationId"))
+                    .setApiKey(FCMConfig.getString("apiKey"))
+                    .setProjectId(FCMConfig.getString("projectId"))
+                    .setGcmSenderId(FCMConfig.getString("senderId"))
+                    .build();
+
+            senderId = FCMConfig.getString("senderId");
+
+            SharedPreferences sharedPref = context.getSharedPreferences(
+                    "zimbraMobile",
+                    Context.MODE_PRIVATE
+            );
+
+            SharedPreferences.Editor editor = sharedPref.edit();
+            editor.putString("senderID", FCMConfig.getString("senderId"));
+            editor.apply();
+
+            objFirebase = FirebaseApp.initializeApp(context, firebaseOptions, "[DEFAULT]");
+            objInstance = new ZimbraFirebaseApp();
+        }
+    }
+    public static FirebaseInstanceId getInstance() {
+        if (objInstance == null) {
+            System.out.println("initialize class first");
+            return null;
+        }
+        return FirebaseInstanceId.getInstance();
+    }
+
+    public static String getSenderId() {
+        return senderId;
+    }
+}

--- a/src/android/com/adobe/phonegap/push/ZimbraFirebaseApp.java
+++ b/src/android/com/adobe/phonegap/push/ZimbraFirebaseApp.java
@@ -1,6 +1,7 @@
 package com.adobe.phonegap.push;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;


### PR DESCRIPTION
To make firebase configuration dynamically by passing FCM configuration details while initializing plugin like below

_push = 
PushNotification.init(
{
      android: {
        icon: "app",
        iconColor: "#2596be",
      },
      fcm: {
        applicationId: client.client_Info.mobilesdk_app_id,
        apiKey: client. api_key[0].current_key,
        projectId: project_info. project_id,
        senderId: project_info. project_number,
      },
    });_

Refer below link to **Get config file for your Android app**

https://support.google.com/firebase/answer/7015592?hl=en#android&zippy=%2Cin-this-article